### PR TITLE
Fix requirement versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.20.1
-pgzero==1.2
-pygame==2.0.1
+numpy>=1.20.1
+pgzero>=1.2.1
+pygame>=2.0.1


### PR DESCRIPTION
## Problem
Mit dem Befehlt
``` phython
pip install pgzero
```
wird pgzero Version `1.2.1` installiert. In der `requirements.txt` ist allerdings die Version `1.2` fest vorgegeben.
Die download Version ist damit inkompatibel und man hat in der IDE keine Change das Spiel zu starten:

> ⚡ `ERROR: Cannot install`
   requirements.txt (line 2) and pygame==2.0.1 because these package versions have conflicting dependencies.

## Lösung

**A**: Version wie die Anderen Requirements fest auf die aktuelle Version ziehen:
```py
# requirements.txt
pgzero==1.2.1
```
**B**: Version wie die Anderen Requirements gleich mit >= auch auf die Nachfolgeversionen erlauben
```py
# requirements.txt
pgzero>=1.2.1
```